### PR TITLE
Rename nicname field

### DIFF
--- a/user_app/migrations/0014_rename_nicname_nickname.py
+++ b/user_app/migrations/0014_rename_nicname_nickname.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('user_app', '0013_alter_user_email'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='user',
+            old_name='nicname',
+            new_name='nickname',
+        ),
+    ]

--- a/user_app/models.py
+++ b/user_app/models.py
@@ -8,6 +8,6 @@ def upload_to(inst, filename):
 class User(AbstractUser):
     # email = models.EmailField(max_length = 55, unique=True)
     username = models.CharField(max_length = 55, unique=False) 
-    nicname = models.CharField(max_length = 55, default='default_nicname')
+    nickname = models.CharField(max_length = 55, default='default_nicname')
     profile_picture = ResizedImageField(upload_to = "", null = True, blank = True)
 


### PR DESCRIPTION
## Summary
- fix typo in user model (nicname -> nickname)
- add migration to rename field

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py migrate` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68496e7f6c5883339b5012404ba506ae